### PR TITLE
fix: update DOI extraction path

### DIFF
--- a/pymed_paperscraper/__init__.py
+++ b/pymed_paperscraper/__init__.py
@@ -1,4 +1,4 @@
 from .api import PubMed
 
 __all__ = ["PubMed"]
-__version__ = "1.0.4"
+__version__ = "1.0.5"

--- a/pymed_paperscraper/article.py
+++ b/pymed_paperscraper/article.py
@@ -81,7 +81,7 @@ class PubMedArticle(object):
         return getContent(element=xml_element, path=path)
 
     def _extractDoi(self: object, xml_element: TypeVar("Element")) -> str:
-        path = ".//ArticleId[@IdType='doi']"
+        path = ".//PubmedData/ArticleIdList/ArticleId[@IdType='doi']"
         return getContent(element=xml_element, path=path)
 
     def _extractPublicationDate(

--- a/pymed_paperscraper/tests/test_article.py
+++ b/pymed_paperscraper/tests/test_article.py
@@ -16,5 +16,7 @@ def test_unique_doi():
 	results = pubmed.query(query, max_results=30)
 
 	for r in results:
+		if r.doi is None:
+			continue
 		dois = r.doi.strip().split("\n")
 		assert len(dois) == 1

--- a/pymed_paperscraper/tests/test_article.py
+++ b/pymed_paperscraper/tests/test_article.py
@@ -9,3 +9,12 @@ def test_unique_id():
 	for r in results:
 		ids = r.pubmed_id.strip().split("\n")
 		assert len(ids) == 1
+
+def test_unique_doi():
+	pubmed = PubMed(tool="MyTool", email="my@email.address")
+	query = '((Haliaeetus leucocephalus[Title/Abstract])) AND ((prey[Title/Abstract]) OR (diet[Title/Abstract]))'
+	results = pubmed.query(query, max_results=30)
+
+	for r in results:
+		dois = r.doi.strip().split("\n")
+		assert len(dois) == 1


### PR DESCRIPTION
  ## Summary
  - Fixed DOI extraction XPath to use correct path
  - Added test for unique DOI validation

  ## Changes
  - Updated `_extractDoi` method in `article.py:84`
  - Added `test_unique_doi` test case